### PR TITLE
Revamp personal site content and tutoring page

### DIFF
--- a/front-end/src/components/EducationComponent.vue
+++ b/front-end/src/components/EducationComponent.vue
@@ -1,20 +1,70 @@
 <script lang="ts" setup>
+import { computed } from "vue";
 import { useMainStore } from "~/stores";
-
 
 const educationStore = useMainStore();
 const education = computed(() => educationStore.$state.userProfile.education);
 </script>
 
 <template>
-  <div class="page">
-    <h1>Education</h1>
-    <div v-for="(item, index) in education" :key="index" class="item">
-      <h2>{{ item.degree }}</h2>
-      <h3>{{ item.institution }}</h3>
-      <p>{{ item.description }}</p>
+  <div>
+    <h2>Education</h2>
+    <div v-for="(item, index) in education" :key="index" class="education-card">
+      <div class="education-card__header">
+        <h3>{{ item.degree }}</h3>
+        <span class="education-card__timeframe">{{ item.timeframe }}</span>
+      </div>
+      <p class="education-card__institution">{{ item.institution }}</p>
+      <p class="education-card__details">{{ item.details }}</p>
+      <ul v-if="item.highlights?.length" class="education-card__highlights">
+        <li v-for="highlight in item.highlights" :key="highlight">{{ highlight }}</li>
+      </ul>
     </div>
   </div>
 </template>
 
-<style scoped></style>
+<style scoped>
+.education-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1.75rem;
+  border-radius: 20px;
+  border: 1px solid rgba(45, 212, 191, 0.25);
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 12px 26px rgba(15, 23, 42, 0.08);
+  margin-bottom: 1.5rem;
+}
+
+.education-card__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.education-card__timeframe {
+  font-weight: 600;
+  color: #0f766e;
+}
+
+.education-card__institution {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.education-card__details {
+  margin: 0;
+  color: #4b5563;
+  line-height: 1.6;
+}
+
+.education-card__highlights {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: #374151;
+  display: grid;
+  gap: 0.4rem;
+}
+</style>

--- a/front-end/src/components/TheFooter.vue
+++ b/front-end/src/components/TheFooter.vue
@@ -1,51 +1,138 @@
 <script lang="ts" setup>
+import { computed } from "vue";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
+import { useMainStore } from "~/stores";
+
+const store = useMainStore();
+const profile = computed(() => store.userProfile);
 </script>
 
 <template>
-  <footer>
-    <h2>Contact</h2>
-    <nav>
-      <ul>
-        <li>
-          <a href="https://www.facebook.com/jacoba1100254352" target="_blank">
-            <FontAwesomeIcon :icon="['fab', 'facebook']" size="2x" />
-          </a>
-        </li>
-        <li>
-          <a href="https://www.github.com/Jacoba1100254352" target="_blank">
-            <FontAwesomeIcon :icon="['fab', 'github']" size="2x" />
-          </a>
-        </li>
-        <li>
-          <a href="https://www.instagram.com/jacoba1100254352" target="_blank">
-            <FontAwesomeIcon :icon="['fab', 'instagram']" size="2x" />
-          </a>
-        </li>
-      </ul>
+  <footer class="footer">
+    <div class="footer__contact">
+      <h2>Let’s build something meaningful</h2>
+      <p>
+        Reach out to collaborate on embedded systems, research initiatives, or to schedule a learning
+        session.
+      </p>
+      <div class="footer__links">
+        <a :href="`mailto:${profile.email}`">{{ profile.email }}</a>
+        <span aria-hidden="true">•</span>
+        <a :href="`tel:${profile.phone}`">{{ profile.phone }}</a>
+      </div>
+    </div>
+    <nav class="footer__social">
+      <a href="https://www.github.com/Jacoba1100254352" target="_blank" rel="noopener">
+        <FontAwesomeIcon :icon="['fab', 'github']" size="lg" />
+        <span class="sr-only">GitHub</span>
+      </a>
+      <a href="https://www.facebook.com/jacoba1100254352" target="_blank" rel="noopener">
+        <FontAwesomeIcon :icon="['fab', 'facebook']" size="lg" />
+        <span class="sr-only">Facebook</span>
+      </a>
+      <a href="https://www.instagram.com/jacoba1100254352" target="_blank" rel="noopener">
+        <FontAwesomeIcon :icon="['fab', 'instagram']" size="lg" />
+        <span class="sr-only">Instagram</span>
+      </a>
     </nav>
+    <RouterLink class="footer__cta" to="/classes">
+      Explore my teaching approach →
+    </RouterLink>
   </footer>
 </template>
 
 <style scoped>
-footer {
-  margin-bottom: 20px;
-  padding: 20px;
-  background-color: #fff;
-  border: 1px solid #ccc;
-  border-radius: 5px;
-  box-shadow: 0 2px 2px rgba(0, 0, 0, 0.1);
-}
-
-footer ul {
+.footer {
+  margin-top: 3rem;
+  padding: 3rem;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 26px;
+  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.08);
   display: flex;
-  justify-content: space-around;
-  list-style: none;
-  padding: 20px 0 0;
+  flex-direction: column;
+  gap: 1.75rem;
+  text-align: center;
 }
 
-a {
+.footer__contact h2 {
+  margin: 0 0 0.75rem;
+}
+
+.footer__contact p {
+  margin: 0;
+  color: #374151;
+}
+
+.footer__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  justify-content: center;
+  align-items: center;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.footer__links a {
+  color: #0f766e;
   text-decoration: none;
-  color: black;
+}
+
+.footer__links a:hover,
+.footer__links a:focus {
+  text-decoration: underline;
+}
+
+.footer__social {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.footer__social a {
+  color: #0f172a;
+  background: rgba(236, 253, 245, 0.85);
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s ease;
+}
+
+.footer__social a:hover,
+.footer__social a:focus {
+  transform: translateY(-2px);
+  color: #0f766e;
+}
+
+.footer__cta {
+  align-self: center;
+  font-weight: 600;
+  color: #0f766e;
+  text-decoration: none;
+}
+
+.footer__cta:hover,
+.footer__cta:focus {
+  text-decoration: underline;
+}
+
+.sr-only {
+  position: absolute;
+  clip: rect(0, 0, 0, 0);
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  border: 0;
+}
+
+@media (max-width: 768px) {
+  .footer {
+    padding: 2.25rem;
+  }
 }
 </style>

--- a/front-end/src/components/TheHeader.vue
+++ b/front-end/src/components/TheHeader.vue
@@ -1,17 +1,33 @@
 <script lang="ts" setup>
-import { ref } from "vue";
-
+import { computed, ref, watch } from "vue";
+import { useRoute } from "vue-router";
 
 const isExpanded = ref(false);
-const activeLink = ref("Home");
+const route = useRoute();
 
-const links = ref([
+const links = [
   { name: "Home", path: "/" },
   { name: "Projects", path: "/projects" },
   { name: "Experience", path: "/experience" },
   { name: "About", path: "/about" },
+  { name: "Classes", path: "/classes" },
   { name: "Contact", path: "/contact" }
-]);
+];
+
+const activeLink = ref(links[0].name);
+
+const activePath = computed(() => route.path);
+
+watch(
+  activePath,
+  (currentPath) => {
+    const match = links.find((link) => currentPath.startsWith(link.path) && link.path !== "/") ||
+      links.find((link) => link.path === currentPath) ||
+      links[0];
+    activeLink.value = match.name;
+  },
+  { immediate: true }
+);
 
 function toggleMenu() {
   isExpanded.value = !isExpanded.value;
@@ -19,22 +35,22 @@ function toggleMenu() {
 
 function setActiveLink(linkName: string) {
   activeLink.value = linkName;
-  isExpanded.value = false; // Close the menu after a link is clicked
+  isExpanded.value = false;
 }
 </script>
 
 <template>
-  <header>
+  <header class="header">
     <nav class="flex-container">
       <div class="logo-container">
-        <RouterLink to="/">
+        <RouterLink to="/" class="logo-link">
           <img
             alt="Jacob Anderson Logo"
             class="logo"
             src="https://jacobdanderson.s3.amazonaws.com/images/Logo+1+Saywa.png"
           />
+          <span class="site-name">Jacob Anderson</span>
         </RouterLink>
-        <span class="site-name">Jacob Anderson</span>
       </div>
       <div class="hamburger" @click="toggleMenu">
         <div :class="{ open: isExpanded }" class="bar" />
@@ -58,14 +74,22 @@ function setActiveLink(linkName: string) {
 </template>
 
 <style scoped>
+.header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  backdrop-filter: blur(16px);
+}
+
 .flex-container {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 10px 20px;
-  background-color: #fff;
-  border-bottom: 1px solid #ccc;
-  position: relative;
+  padding: 1.25rem clamp(1rem, 4vw, 2rem);
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 22px;
+  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.08);
+  margin-bottom: 2rem;
 }
 
 .logo-container {
@@ -73,53 +97,81 @@ function setActiveLink(linkName: string) {
   align-items: center;
 }
 
+.logo-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  text-decoration: none;
+}
+
 .logo {
-  width: 50px;
+  width: 52px;
   height: auto;
-  margin-right: 10px;
 }
 
 .site-name {
-  font-size: 1.5em;
-  font-weight: bold;
-  color: #333;
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #0f172a;
+  letter-spacing: 0.02em;
 }
 
 .nav-links {
   display: flex;
-  gap: 30px;
+  gap: 1.5rem;
   list-style: none;
-  margin: 10px;
+  margin: 0;
   padding: 0;
+  align-items: center;
+}
+
+.nav-links li {
+  position: relative;
 }
 
 .nav-link {
   text-decoration: none;
-  color: #333;
-  font-size: 1em;
-  padding: 0 10px;
+  color: #1f2937;
+  font-weight: 600;
+  padding-bottom: 0.35rem;
+  display: inline-flex;
+  transition: color 0.2s ease;
 }
 
-.nav-link:hover {
-  color: #007bff;
+.nav-links li.active .nav-link,
+.nav-link:hover,
+.nav-link:focus {
+  color: #0f766e;
+}
+
+.nav-links li.active::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -0.4rem;
+  width: 100%;
+  height: 3px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #0f766e, #14b8a6);
 }
 
 .hamburger {
   display: none;
   flex-direction: column;
   cursor: pointer;
+  gap: 0.35rem;
 }
 
 .bar {
-  width: 25px;
+  width: 28px;
   height: 3px;
-  background-color: #333;
-  margin: 4px 0;
-  transition: 0.4s;
+  background-color: #0f172a;
+  border-radius: 999px;
+  transition: transform 0.3s ease, opacity 0.3s ease;
 }
 
 .bar.open:nth-child(1) {
-  transform: rotate(-45deg) translate(-5px, 6px);
+  transform: translateY(6px) rotate(-45deg);
 }
 
 .bar.open:nth-child(2) {
@@ -127,35 +179,37 @@ function setActiveLink(linkName: string) {
 }
 
 .bar.open:nth-child(3) {
-  transform: rotate(45deg) translate(-5px, -6px);
+  transform: translateY(-6px) rotate(45deg);
 }
 
-@media (max-width: 768px) {
+@media (max-width: 900px) {
+  .flex-container {
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
   .hamburger {
     display: flex;
   }
-  
+
   .nav-links {
-    display: none;
-    flex-direction: column;
     width: 100%;
-    background-color: #fff;
-    position: absolute;
-    top: 60px;
-    left: 0; /* Center horizontally */
-    transform: translateX(-3%); /* Shift to the center */
-    padding: 20px;
-    border-top: 1px solid #ccc;
-    border-bottom: 1px solid #ccc;
+    flex-direction: column;
+    align-items: flex-start;
+    display: none;
+    padding-top: 0.75rem;
   }
-  
+
   .nav-links.expanded {
     display: flex;
   }
-  
+
   .nav-links li {
-    margin: 10px 0;
-    text-align: center;
+    width: 100%;
+  }
+
+  .nav-links li.active::after {
+    display: none;
   }
 }
 </style>

--- a/front-end/src/pages/about.vue
+++ b/front-end/src/pages/about.vue
@@ -1,57 +1,249 @@
 <script lang="ts" setup>
 import { computed } from "vue";
-import { useMainStore } from "~/stores"; // Ensure this points to your configured Pinia store
+import { useMainStore } from "~/stores";
 
+const props = defineProps<{ condensed?: boolean }>();
 const store = useMainStore();
-const about = computed(() => store.userProfile.about); // Accessing 'about' directly from the Pinia store
+const profile = computed(() => store.userProfile);
+const heroHighlights = computed(() => profile.value.heroHighlights);
+const skills = computed(() => profile.value.skills);
+const showFullProfile = computed(() => !props.condensed);
 </script>
 
 <template>
   <div class="page">
-    <img
-      v-if="$route.path === '/'"
-      alt="Jacob Anderson Logo"
-      class="logo"
-      src="https://jacobdanderson.s3.amazonaws.com/images/Logo 2 Saywa.png"
-    />
-    <img
-      v-if="$route.path !== '/'"
-      alt="Profile Picture"
-      class="profile-pic"
-      src="https://jacobdanderson.s3.amazonaws.com/images/Jacob_Anderson.jpg"
-    />
-    <div class="item">
-      <h1>About Me</h1>
-      <p>{{ about }}</p>
-    </div>
-    
-    <!-- Do not show Education Component on home page -->
-    <EducationComponent v-if="$route.path !== '/'" />
+    <section class="hero">
+      <div class="hero__content">
+        <p class="hero__location">{{ profile.location }}</p>
+        <h1>{{ profile.name }}</h1>
+        <p class="hero__tagline">{{ profile.tagline }}</p>
+        <p class="hero__summary">{{ profile.about }}</p>
+        <div class="hero__highlights">
+          <span
+            v-for="(highlight, index) in heroHighlights"
+            :key="index"
+            class="hero__chip"
+          >
+            {{ highlight }}
+          </span>
+        </div>
+        <div class="hero__contact">
+          <a :href="`mailto:${profile.email}`">{{ profile.email }}</a>
+          <span aria-hidden="true">•</span>
+          <a :href="`tel:${profile.phone}`">{{ profile.phone }}</a>
+        </div>
+      </div>
+      <div class="hero__media">
+        <img
+          alt="Jacob Anderson smiling"
+          class="hero__portrait"
+          src="https://jacobdanderson.s3.amazonaws.com/images/Jacob_Anderson.jpg"
+        />
+      </div>
+    </section>
+
+    <section v-if="showFullProfile" class="section">
+      <h2>Core Skills</h2>
+      <div class="skills-grid">
+        <div class="skills-card">
+          <h3>Programming Languages</h3>
+          <ul>
+            <li v-for="item in skills.programmingLanguages" :key="item">{{ item }}</li>
+          </ul>
+        </div>
+        <div class="skills-card">
+          <h3>Frameworks &amp; Tools</h3>
+          <ul>
+            <li v-for="item in skills.frameworksAndTools" :key="item">{{ item }}</li>
+          </ul>
+        </div>
+        <div class="skills-card">
+          <h3>Technical Focus</h3>
+          <ul>
+            <li v-for="item in skills.competencies" :key="item">{{ item }}</li>
+          </ul>
+        </div>
+        <div class="skills-card">
+          <h3>Languages</h3>
+          <ul>
+            <li v-for="item in skills.spokenLanguages" :key="item">{{ item }}</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section v-if="showFullProfile" class="section">
+      <EducationComponent />
+    </section>
+
+    <section v-if="showFullProfile" class="section achievements">
+      <h2>Achievements</h2>
+      <ul>
+        <li v-for="achievement in profile.achievements" :key="achievement">
+          {{ achievement }}
+        </li>
+      </ul>
+    </section>
   </div>
 </template>
 
 <style scoped>
-.logo {
-  display: block;
-  width: 150px; /* Adjust size as needed */
-  height: auto;
-  margin: 0 auto 20px;
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
 }
 
-.profile-pic {
-  display: block;
-  border-radius: 50%;
-  width: 150px;
-  height: 150px;
+.hero {
+  display: grid;
+  gap: 2.5rem;
+  align-items: center;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  padding: 2.5rem 3rem;
+  background: linear-gradient(135deg, rgba(17, 94, 89, 0.1), rgba(13, 148, 136, 0.25));
+  border-radius: 24px;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+}
+
+.hero__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.hero__location {
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(15, 118, 110, 0.85);
+}
+
+.hero__tagline {
+  font-size: 1.3rem;
+  color: #1f2937;
+  font-weight: 600;
+  line-height: 1.5;
+}
+
+.hero__summary {
+  font-size: 1.05rem;
+  line-height: 1.7;
+  color: #374151;
+}
+
+.hero__highlights {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.hero__chip {
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(45, 212, 191, 0.4);
+  padding: 0.5rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  color: #0f766e;
+  box-shadow: 0 12px 20px rgba(15, 118, 110, 0.1);
+}
+
+.hero__contact {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.hero__contact a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.hero__contact a:hover,
+.hero__contact a:focus {
+  text-decoration: underline;
+}
+
+.hero__media {
+  display: flex;
+  justify-content: center;
+}
+
+.hero__portrait {
+  width: min(280px, 100%);
+  aspect-ratio: 1/1;
   object-fit: cover;
-  margin: 20px auto;
+  border-radius: 28px;
+  border: 6px solid rgba(255, 255, 255, 0.9);
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.15);
+}
+
+.section {
+  background: #ffffff;
+  padding: 2.5rem;
+  border-radius: 24px;
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.08);
+}
+
+.section h2 {
+  margin-bottom: 1.5rem;
+  color: #0f172a;
+}
+
+.skills-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.skills-card {
+  border-radius: 18px;
+  border: 1px solid rgba(45, 212, 191, 0.2);
+  padding: 1.5rem;
+  background: rgba(236, 253, 245, 0.55);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8);
+}
+
+.skills-card h3 {
+  margin-bottom: 1rem;
+  font-size: 1.05rem;
+  color: #0f766e;
+}
+
+.skills-card ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: #1f2937;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.achievements ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: #1f2937;
+  display: grid;
+  gap: 0.5rem;
+  font-size: 1.05rem;
+}
+
+@media (max-width: 768px) {
+  .hero {
+    padding: 2rem;
+  }
+
+  .hero__chip {
+    font-size: 0.9rem;
+  }
 }
 </style>
 
 <route lang="json">
 {
-"meta": {
-"layout": "default"
-}
+  "meta": {
+    "layout": "default"
+  }
 }
 </route>

--- a/front-end/src/pages/classes.vue
+++ b/front-end/src/pages/classes.vue
@@ -1,0 +1,188 @@
+<script lang="ts" setup>
+import { computed } from "vue";
+import { useMainStore } from "~/stores";
+
+const store = useMainStore();
+const teaching = computed(() => store.userProfile.teaching);
+const profile = computed(() => store.userProfile);
+</script>
+
+<template>
+  <div class="page classes">
+    <section class="classes__hero">
+      <h1>1:1 Lessons with Jacob</h1>
+      <p>
+        I help students build confidence in programming, STEM foundations, and Spanish through engaging,
+        project-based lessons tailored to their goals.
+      </p>
+      <a :href="teaching.link" class="classes__cta" target="_blank" rel="noopener">
+        Book a lesson at classes.jacobdanderson.net
+      </a>
+    </section>
+
+    <section class="classes__grid">
+      <article class="classes__card">
+        <h2>What I Teach</h2>
+        <ul>
+          <li v-for="area in teaching.focusAreas" :key="area">{{ area }}</li>
+        </ul>
+      </article>
+      <article class="classes__card">
+        <h2>How It Works</h2>
+        <ul>
+          <li>Live, one-on-one sessions for students ages 7–18.</li>
+          <li>Customized weekly or bi-weekly meeting cadence.</li>
+          <li>Hands-on projects that make complex ideas approachable.</li>
+        </ul>
+      </article>
+      <article class="classes__card">
+        <h2>Rates &amp; Availability</h2>
+        <p class="classes__rate">${{ teaching.rate }} per 50-minute lesson</p>
+        <ul>
+          <li>Weeknight and Saturday sessions available.</li>
+          <li>Flexible scheduling for academic calendars.</li>
+          <li>Progress updates sent to parents after every lesson.</li>
+        </ul>
+      </article>
+    </section>
+
+    <section class="classes__testimonial">
+      <h2>Why families enjoy working with me</h2>
+      <p>
+        As an Instructor Success Trainer at Juni Learning, I coach instructors on delivering memorable,
+        student-centered lessons. I bring that same energy to each session, blending technical depth with
+        patience and bilingual communication when needed.
+      </p>
+      <div class="classes__contact">
+        <span>Email me at</span>
+        <a :href="`mailto:${profile.email}`">{{ profile.email }}</a>
+        <span>or call</span>
+        <a :href="`tel:${profile.phone}`">{{ profile.phone }}</a>
+      </div>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.classes {
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}
+
+.classes__hero {
+  background: linear-gradient(135deg, rgba(13, 148, 136, 0.15), rgba(20, 184, 166, 0.3));
+  border-radius: 28px;
+  padding: 3rem;
+  box-shadow: 0 20px 44px rgba(15, 23, 42, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  text-align: left;
+}
+
+.classes__hero h1 {
+  margin: 0;
+}
+
+.classes__hero p {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #0f172a;
+  line-height: 1.7;
+}
+
+.classes__cta {
+  align-self: flex-start;
+  background: #0f766e;
+  color: #ffffff;
+  padding: 0.85rem 1.5rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.classes__cta:hover,
+.classes__cta:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 22px rgba(15, 118, 110, 0.2);
+}
+
+.classes__grid {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.classes__card {
+  background: #ffffff;
+  border-radius: 24px;
+  padding: 2.25rem;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.classes__card ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: #374151;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.classes__rate {
+  margin: 0;
+  font-weight: 700;
+  color: #0f766e;
+}
+
+.classes__testimonial {
+  background: #ffffff;
+  border-radius: 24px;
+  padding: 2.5rem;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.classes__testimonial p {
+  margin: 0;
+  color: #374151;
+  line-height: 1.7;
+}
+
+.classes__contact {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.75rem;
+  align-items: center;
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.classes__contact a {
+  color: #0f766e;
+}
+
+@media (max-width: 768px) {
+  .classes__hero {
+    padding: 2.25rem;
+  }
+
+  .classes__card {
+    padding: 2rem;
+  }
+}
+</style>
+
+<route lang="json">
+{
+  "meta": {
+    "layout": "default"
+  }
+}
+</route>

--- a/front-end/src/pages/contact.vue
+++ b/front-end/src/pages/contact.vue
@@ -1,117 +1,108 @@
 <script lang="ts" setup>
-import { ref } from "vue";
+import { computed } from "vue";
+import { useMainStore } from "~/stores";
 
-
-const form = ref({
-  name: "",
-  email: "",
-  message: ""
-});
-
-function handleSubmit() {
-  console.log("Form submitted:", form.value);
-  // eslint-disable-next-line no-alert
-  alert("Message sent! We'll get back to you soon.");
-  
-  // Reset form after submission
-  form.value.name = "";
-  form.value.email = "";
-  form.value.message = "";
-}
+const store = useMainStore();
+const profile = computed(() => store.userProfile);
 </script>
 
 <template>
-  <div class="page">
-    <div class="item">
-      <h1>Contact Me</h1>
+  <div class="page contact">
+    <section class="contact__card">
+      <h1>Connect with Jacob</h1>
       <p>
-        If you have any questions or feedback, please feel free to reach out to
-        us through the form below.
+        I enjoy collaborating on research-driven engineering, embedded systems, and meaningful learning
+        opportunities. The fastest way to reach me is by email, and I am happy to schedule a call.
       </p>
-      
-      <form @submit.prevent="handleSubmit">
-        <div class="form-group">
-          <label for="name">Name:</label>
-          <input id="name" v-model="form.name" required type="text" />
+
+      <div class="contact__details">
+        <div>
+          <span>Email</span>
+          <a :href="`mailto:${profile.email}`">{{ profile.email }}</a>
         </div>
-        
-        <div class="form-group">
-          <label for="email">Email:</label>
-          <input id="email" v-model="form.email" required type="email" />
+        <div>
+          <span>Phone</span>
+          <a :href="`tel:${profile.phone}`">{{ profile.phone }}</a>
         </div>
-        
-        <div class="form-group">
-          <label for="message">Message:</label>
-          <textarea id="message" v-model="form.message" required rows="4" />
+        <div>
+          <span>Location</span>
+          <p>{{ profile.location }}</p>
         </div>
-        
-        <button type="submit">Send Message</button>
-      </form>
-    </div>
+      </div>
+
+      <RouterLink class="contact__cta" to="/classes">
+        Interested in private lessons? Explore my teaching approach →
+      </RouterLink>
+    </section>
   </div>
 </template>
 
 <style scoped>
-.form-group {
-  margin-bottom: 20px;
+.contact {
+  display: flex;
+  justify-content: center;
 }
 
-.form-group label {
+.contact__card {
+  background: #ffffff;
+  border-radius: 24px;
+  padding: 3rem;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.1);
+  max-width: 720px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  text-align: left;
+}
+
+.contact__card p {
+  margin: 0;
+  color: #374151;
+  line-height: 1.7;
+}
+
+.contact__details {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.contact__details span {
   display: block;
-  margin-bottom: 5px;
+  font-weight: 600;
+  color: #0f766e;
+  margin-bottom: 0.25rem;
 }
 
-.form-group input[type="text"],
-.form-group input[type="email"],
-.form-group textarea {
-  width: 100%;
-  min-width: 600px;
-  padding: 8px;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  background-color: #fff; /* Default light mode background */
-  color: #000; /* Default light mode text color */
+.contact__details a,
+.contact__details p {
+  margin: 0;
+  color: #1f2937;
 }
 
-/* Dark mode styles */
-body.dark .form-group input[type="text"],
-body.dark .form-group input[type="email"],
-body.dark .form-group textarea {
-  background-color: #333; /* Dark mode background */
-  color: #fff; /* Dark mode text color */
-  border: 1px solid #666; /* Dark mode border color */
+.contact__cta {
+  align-self: flex-start;
+  font-weight: 600;
+  color: #0f766e;
+  text-decoration: none;
 }
 
-button[type="submit"] {
-  background-color: #4caf50;
-  color: white;
-  padding: 10px 20px;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
+.contact__cta:hover,
+.contact__cta:focus {
+  text-decoration: underline;
 }
 
-button[type="submit"]:hover {
-  background-color: #45a049;
-}
-
-@media (max-width: 800px) {
-  .item {
-    max-width: 100%;
-  }
-  
-  .form-group input[type="text"],
-  .form-group input[type="email"],
-  .form-group textarea {
-    min-width: auto;
+@media (max-width: 768px) {
+  .contact__card {
+    padding: 2.25rem;
   }
 }
 </style>
 
 <route lang="json">
 {
-"meta": {
-"layout": "default"
-}
+  "meta": {
+    "layout": "default"
+  }
 }
 </route>

--- a/front-end/src/pages/experience.vue
+++ b/front-end/src/pages/experience.vue
@@ -2,28 +2,78 @@
 import { computed } from "vue";
 import { useMainStore } from "~/stores";
 
-
 const store = useMainStore();
-const experience = computed(() => store.userProfile.experience);
+const experience = computed(() => store.userProfile.experiences);
 </script>
 
 <template>
   <div class="page">
     <h1>Experience</h1>
-    <div v-for="(item, index) in experience" :key="index" class="item">
-      <h2>{{ item.role }}</h2>
-      <h3>{{ item.location }}</h3>
-      <p>{{ item.description }}</p>
+    <div v-for="(item, index) in experience" :key="index" class="experience-card">
+      <div class="experience-card__header">
+        <div>
+          <h2>{{ item.role }}</h2>
+          <p class="experience-card__company">{{ item.company }} • {{ item.location }}</p>
+        </div>
+        <span class="experience-card__timeframe">{{ item.timeframe }}</span>
+      </div>
+      <ul class="experience-card__highlights">
+        <li v-for="highlight in item.highlights" :key="highlight">{{ highlight }}</li>
+      </ul>
     </div>
   </div>
 </template>
 
-<style scoped></style>
+<style scoped>
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.experience-card {
+  background: #ffffff;
+  border-radius: 24px;
+  padding: 2rem;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(45, 212, 191, 0.18);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.experience-card__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.experience-card__company {
+  margin: 0;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.experience-card__timeframe {
+  font-weight: 600;
+  color: #0f766e;
+}
+
+.experience-card__highlights {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: #374151;
+  display: grid;
+  gap: 0.5rem;
+}
+</style>
 
 <route lang="json">
 {
-"meta": {
-"layout": "default"
-}
+  "meta": {
+    "layout": "default"
+  }
 }
 </route>

--- a/front-end/src/pages/index.vue
+++ b/front-end/src/pages/index.vue
@@ -1,76 +1,223 @@
 <script lang="ts" setup>
+import { computed } from "vue";
+import { useMainStore } from "~/stores";
 import About from "~/pages/about.vue";
-import Experience from "~/pages/experience.vue";
-import Projects from "~/pages/projects.vue";
 
-
-defineOptions({
-  name: "IndexPage"
-});
-
-/*
-// Option for dynamic routing
-const router = useRouter()
-function go() {
-	if (name.value)
-		router.push(`/hi/${encodeURIComponent(name.value)}`)
-} */
-
-/*
-// TODO: Check out what this does later
-const { t } = useI18n()
-useHead({
-	title: () => t('button.home'),
-}) */
+const store = useMainStore();
+const profile = computed(() => store.userProfile);
+const featuredExperiences = computed(() => profile.value.experiences.slice(0, 2));
+const featuredProjects = computed(() => profile.value.projects.slice(0, 3));
+const teaching = computed(() => profile.value.teaching);
 </script>
 
 <template>
-  <div class="page">
-    <About class="about" />
-    <div class="projects-experience">
-      <Projects class="projects" />
-      <Experience class="experience" />
-    </div>
+  <div class="home">
+    <About condensed class="home__about" />
+
+    <section class="home__section">
+      <h2>Recent Highlights</h2>
+      <div class="home__grid">
+        <article
+          v-for="(item, index) in featuredExperiences"
+          :key="index"
+          class="home__card"
+        >
+          <h3>{{ item.role }}</h3>
+          <p class="home__card-subtitle">
+            {{ item.company }} • {{ item.timeframe }}
+          </p>
+          <ul>
+            <li v-for="highlight in item.highlights" :key="highlight">{{ highlight }}</li>
+          </ul>
+        </article>
+        <article class="home__card">
+          <h3>Now Teaching</h3>
+          <p class="home__card-subtitle">
+            Personalized lessons for ages 7–18
+          </p>
+          <ul>
+            <li v-for="area in teaching.focusAreas" :key="area">{{ area }}</li>
+          </ul>
+          <p class="home__cta">
+            ${{ teaching.rate }} per lesson ·
+            <RouterLink class="home__cta-link" to="/classes">See how I teach</RouterLink>
+          </p>
+        </article>
+      </div>
+    </section>
+
+    <section class="home__section">
+      <h2>Selected Projects</h2>
+      <div class="home__projects">
+        <article
+          v-for="(project, index) in featuredProjects"
+          :key="index"
+          class="home__project-card"
+        >
+          <header>
+            <h3>{{ project.name }}</h3>
+            <span>{{ project.timeframe }}</span>
+          </header>
+          <p>{{ project.description }}</p>
+          <ul v-if="project.tech?.length">
+            <li v-for="tag in project.tech" :key="tag">{{ tag }}</li>
+          </ul>
+        </article>
+      </div>
+      <RouterLink class="home__link" to="/projects">View the full project gallery →</RouterLink>
+    </section>
   </div>
 </template>
 
 <style scoped>
-.about {
-  width: 100%;
-}
-
-.projects-experience {
+.home {
   display: flex;
-  flex-direction: row;
-  width: 100%;
+  flex-direction: column;
+  gap: 3rem;
 }
 
-.projects,
-.experience {
-  width: 50%;
+.home__section {
+  background: #ffffff;
+  border-radius: 24px;
+  padding: 2.5rem;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
 }
 
-.projects {
-  margin-right: 10px;
+.home__section h2 {
+  margin: 0;
+  color: #0f172a;
 }
 
-@media (max-width: 600px) {
-  .projects-experience {
-    flex-direction: column;
-  }
-  
-  .projects,
-  .experience {
-    width: 100%;
-    margin: 0;
+.home__grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.home__card {
+  background: rgba(236, 253, 245, 0.75);
+  border-radius: 20px;
+  padding: 1.75rem;
+  border: 1px solid rgba(45, 212, 191, 0.25);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.home__card h3 {
+  margin: 0;
+  color: #0f766e;
+}
+
+.home__card-subtitle {
+  margin: 0;
+  color: #1f2937;
+  font-weight: 600;
+}
+
+.home__card ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: #374151;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.home__cta {
+  margin: 0;
+  color: #0f172a;
+  font-weight: 600;
+}
+
+.home__cta-link {
+  color: #0f766e;
+}
+
+.home__cta-link:hover,
+.home__cta-link:focus {
+  text-decoration: underline;
+}
+
+.home__projects {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.home__project-card {
+  padding: 1.75rem;
+  border-radius: 20px;
+  border: 1px solid rgba(45, 212, 191, 0.25);
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 15px 30px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.home__project-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.home__project-card header span {
+  color: #0f766e;
+  font-weight: 600;
+}
+
+.home__project-card p {
+  margin: 0;
+  color: #374151;
+  line-height: 1.6;
+}
+
+.home__project-card ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.home__project-card li {
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(236, 253, 245, 0.9);
+  color: #0f766e;
+  border: 1px solid rgba(45, 212, 191, 0.3);
+  font-size: 0.85rem;
+}
+
+.home__link {
+  align-self: flex-end;
+  color: #0f766e;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.home__link:hover,
+.home__link:focus {
+  text-decoration: underline;
+}
+
+@media (max-width: 768px) {
+  .home__section {
+    padding: 2rem;
   }
 }
 </style>
 
 <route lang="json">
 {
-"meta": {
-"layout": "default"
-}
+  "meta": {
+    "layout": "default"
+  }
 }
 </route>

--- a/front-end/src/pages/projects.vue
+++ b/front-end/src/pages/projects.vue
@@ -2,7 +2,6 @@
 import { computed } from "vue";
 import { useMainStore } from "~/stores";
 
-
 const store = useMainStore();
 const projects = computed(() => store.userProfile.projects);
 </script>
@@ -10,19 +9,86 @@ const projects = computed(() => store.userProfile.projects);
 <template>
   <div class="page">
     <h1>Projects</h1>
-    <div v-for="(project, index) in projects" :key="index" class="item">
-      <h2>{{ project.name }}</h2>
-      <p>{{ project.description }}</p>
+    <div class="projects-grid">
+      <article v-for="(project, index) in projects" :key="index" class="project-card">
+        <div class="project-card__header">
+          <h2>{{ project.name }}</h2>
+          <span class="project-card__timeframe">{{ project.timeframe }}</span>
+        </div>
+        <p class="project-card__description">{{ project.description }}</p>
+        <ul v-if="project.tech?.length" class="project-card__tags">
+          <li v-for="tag in project.tech" :key="tag">{{ tag }}</li>
+        </ul>
+      </article>
     </div>
   </div>
 </template>
 
-<style scoped></style>
+<style scoped>
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.projects-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.project-card {
+  background: #ffffff;
+  border-radius: 22px;
+  padding: 2rem;
+  box-shadow: 0 15px 32px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(45, 212, 191, 0.18);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.project-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.project-card__timeframe {
+  font-weight: 600;
+  color: #0f766e;
+}
+
+.project-card__description {
+  margin: 0;
+  color: #374151;
+  line-height: 1.6;
+}
+
+.project-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.project-card__tags li {
+  padding: 0.35rem 0.75rem;
+  background: rgba(236, 253, 245, 0.9);
+  color: #0f766e;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  border: 1px solid rgba(45, 212, 191, 0.35);
+}
+</style>
 
 <route lang="json">
 {
-"meta": {
-"layout": "default"
-}
+  "meta": {
+    "layout": "default"
+  }
 }
 </route>

--- a/front-end/src/stores/index.ts
+++ b/front-end/src/stores/index.ts
@@ -1,146 +1,243 @@
 import { defineStore } from "pinia";
 
+export interface ExperienceItem {
+  role: string;
+  company: string;
+  location: string;
+  timeframe: string;
+  highlights: string[];
+}
+
+export interface ProjectItem {
+  name: string;
+  timeframe: string;
+  description: string;
+  tech?: string[];
+}
+
+export interface EducationItem {
+  degree: string;
+  institution: string;
+  timeframe: string;
+  details: string;
+  highlights?: string[];
+}
+
+export interface Skills {
+  programmingLanguages: string[];
+  frameworksAndTools: string[];
+  competencies: string[];
+  spokenLanguages: string[];
+}
+
+export interface UserProfile {
+  name: string;
+  location: string;
+  email: string;
+  phone: string;
+  tagline: string;
+  about: string;
+  heroHighlights: string[];
+  education: EducationItem[];
+  experiences: ExperienceItem[];
+  projects: ProjectItem[];
+  skills: Skills;
+  achievements: string[];
+  teaching: {
+    rate: number;
+    summary: string;
+    focusAreas: string[];
+    link: string;
+  };
+}
 
 export const useMainStore = defineStore("main", {
   state: () => ({
     userProfile: {
       name: "Jacob Anderson",
-      age: 24,
-      interests: [
-        "Music",
-        "Programming",
-        "Chess",
-        "Playing Piano",
-        "Hardware Design",
-        "Mentoring Others"
-      ],
+      location: "Alpharetta, Georgia",
+      email: "jacobdanderson@gmail.com",
+      phone: "404-626-0025",
+      tagline:
+        "Computer engineer focused on resilient embedded systems, data-driven research, and impactful learning experiences.",
       about:
-        "My name is Jacob Anderson, I am from Georgia and absolutely love music! I have a passion for programming and hardware design, and I enjoy mentoring others and contributing to projects with practical outcomes.",
+        "I am a computer engineer and educator who enjoys building embedded systems that solve real-world problems and mentoring students as they master new skills.",
+      heroHighlights: [
+        "M.S. Computer Engineering student at Georgia Tech (August 2025 – Present)",
+        "B.S. Computer Engineering, Minor in Computer Science, Brigham Young University (GPA 3.79)",
+        "Experience across embedded systems, radiation-effects research, and STEM instruction"
+      ],
       education: [
         {
-          degree: "Bachelor of Computer Engineering, Minor: Computer Science",
-          institution: "Brigham Young University, Provo, UT",
-          description: "Current GPA: 3.78, August 2020 to Present"
+          degree: "M.S. Computer Engineering (in progress)",
+          institution: "Georgia Institute of Technology",
+          timeframe: "Aug 2025 – Present",
+          details: "Graduate studies exploring advanced computer engineering topics and resilient system design.",
+          highlights: ["Continuing research interests in embedded sensing and radiation effects."]
         },
         {
-          degree: "Dual Enrollment",
-          institution: "Georgia State University",
-          description: "GPA 3.52, Aug 2017 to May 2018"
+          degree: "B.S. Computer Engineering, Minor in Computer Science",
+          institution: "Brigham Young University",
+          timeframe: "Aug 2020 – Apr 2025",
+          details: "Graduated with a 3.79 GPA; coursework in embedded systems, digital design, software construction, and networking.",
+          highlights: [
+            "Senior Capstone: Designed the interface and communication subsystem for Epiroc's industrial drill monitoring platform.",
+            "Research assistant focusing on non-invasive glucose monitoring and radiation-effects simulation frameworks."
+          ]
         }
       ],
-      work: [
+      experiences: [
+        {
+          role: "Private Instructor & Instructor Success Trainer",
+          company: "Juni Learning",
+          location: "Remote",
+          timeframe: "May 2021 – Present",
+          highlights: [
+            "Teach one-on-one programming, STEM, and Spanish lessons for students ages 7–18.",
+            "Adapt sessions to a wide range of learning styles and goals.",
+            "Mentor new instructors and review curriculum delivery as an Instructor Success Trainer."
+          ]
+        },
         {
           role: "Undergraduate Research Assistant",
           company: "Brigham Young University",
-          description:
-            "Assisted in developing a non-invasive glucose device with Dr. Chiang and Dr. Davis, focusing on system integration and data analysis. Sep 2022 to Present"
+          location: "Provo, UT",
+          timeframe: "Sep 2022 – Oct 2024",
+          highlights: [
+            "Co-developed non-invasive glucose monitoring prototypes with a multidisciplinary team.",
+            "Created MATLAB and Python signal-processing workflows to calibrate sensors and analyze clinical data.",
+            "Contributed to the Purdue SCALE OSCRE framework to improve single-event effect simulations and co-authored the initial technical paper."
+          ]
         },
         {
-          role: "Private Instructor and Instructor Success Trainer (IST)",
-          company: "Juni Learning",
-          description:
-            "Taught youth (7-18) programming, math, and science 1-on-1, with a focus on real-world applications. May 2021 to April 2024"
+          role: "IMMERSE Summer Researcher",
+          company: "Purdue SCALE & Brigham Young University",
+          location: "Provo, UT",
+          timeframe: "Summer 2024",
+          highlights: [
+            "Led integration of the open-source OSCRE radiation-effects simulation framework.",
+            "Automated toolchain setup for Xschem and Ngspice to accelerate SEE analysis.",
+            "Documented workflows and collaborated across institutions to guide future contributors."
+          ]
+        },
+        {
+          role: "Capstone Engineer – Industrial Drill Sensor Integration",
+          company: "Epiroc / Brigham Young University",
+          location: "Provo, UT",
+          timeframe: "Jan 2024 – Apr 2024",
+          highlights: [
+            "Designed the embedded interface for real-time temperature and pressure monitoring.",
+            "Implemented I2C sensor communication and BLE data streaming to the supervisory server.",
+            "Delivered a production-ready operator display for drill status insights."
+          ]
+        },
+        {
+          role: "Programmer & Web Designer",
+          company: "AudioT & Freelance",
+          location: "Remote",
+          timeframe: "May 2020 – Jun 2021",
+          highlights: [
+            "Developed web experiences with HTML, CSS, JavaScript, and Vue for academic and startup partners.",
+            "Programmed Raspberry Pi prototypes with Python and Bash to support AudioT's product experiments.",
+            "Managed deployments and iterative feature updates with an emphasis on usability."
+          ]
         },
         {
           role: "Full-Time Service Volunteer",
-          company: "The Church of Jesus Christ of Latter-day Saints, Ecuador",
-          description:
-            "Held leadership/manager positions over 12 volunteers, coordinating efforts and providing training. July 2018 to Apr 2020"
-        },
-        {
-          role: "Programmer and Assistant",
-          company: "AudioT",
-          description:
-            "Worked for the start-up AudioT, programming Raspberry Pi’s using Python and Bash. May 2020 to August 2020"
-        },
-        {
-          role: "Web Designer",
-          company: "Freelance",
-          description:
-            "Developed and maintained websites using HTML, CSS, JavaScript, and Vue for various clients. July 2020 to June 2021"
-        }
-      ],
-      skills: [
-        "Fluent in Spanish – Reading and Writing proficiency Moderate to High",
-        "Programming – C, C++, Java, TypeScript, Python, System Verilog, HTML, CSS, JavaScript (moderate fluency), Scratch, RISC-V Assembly, React, and Vue",
-        "Hardware Design – System Integration, Circuit Design, Data Analysis",
-        "Mentorship – Teaching programming, math, and science to youth and peers"
-      ],
-      achievements: [
-        "Rank of Eagle Scout in the BSA organization",
-        "Phi Eta Sigma Honor Society Member",
-        "Contributor to a non-invasive glucose monitoring device research project"
-      ],
-      otherActivities: [
-        "Study Abroad at Georgia Tech Lorraine in Metz, France, Winter semesters of 2015 and 2016",
-        "First Lego League Robotics Team 2011 to 2014",
-        "Shakespeare Tavern of Atlanta, Volunteer",
-        "Community service involvement, including Project Read in Provo"
-      ],
-      experience: [
-        {
-          role: "Research Assistant",
-          location: "BYU",
-          description:
-            "Assisting in research for developing a non-invasive glucose monitoring device, with a focus on system integration and data analysis."
-        },
-        {
-          role: "Employee",
-          location: "Chick-Fil-A",
-          description:
-            "Worked at Chick-Fil-A, gaining experience in customer service and teamwork."
-        },
-        {
-          role: "Employee",
-          location: "Crumbl",
-          description:
-            "Worked at Crumbl over the summer, focusing on customer service and product preparation."
-        },
-        {
-          role: "Web Developer",
-          location: "Freelance",
-          description:
-            "Developed websites for clients, including a basic website for my Dad using HTML and CSS."
-        },
-        {
-          role: "Web Developer",
-          location: "Startup",
-          description:
-            "Worked on web development for a startup initiated by one of my dad's students, contributing to the growth of the project."
+          company: "Ecuador Mission",
+          location: "Ecuador",
+          timeframe: "Jul 2018 – Apr 2020",
+          highlights: [
+            "Coordinated training and assignments for a district of 12 volunteers.",
+            "Maintained operational records while serving communities 10+ hours daily.",
+            "Developed leadership, resilience, and bilingual communication skills."
+          ]
         }
       ],
       projects: [
         {
-          name: "Website for Dad",
+          name: "Industrial Drill Monitoring Platform",
+          timeframe: "2024",
           description:
-            "Developed a basic website for my Dad using HTML and CSS."
+            "Capstone system that streams drill temperature and pressure data to operators in real time using BLE and custom embedded firmware.",
+          tech: ["C", "I2C", "BLE", "Embedded UI"]
         },
         {
-          name: "Student Startup Website",
+          name: "Open-Source Circuit Radiation Effects (OSCRE)",
+          timeframe: "2024",
           description:
-            "Developed and maintained a website for a startup initiated by one of my dad's students."
+            "Collaborative Purdue SCALE framework integrating Xschem and Ngspice tooling to simulate single-event effects in radiation environments.",
+          tech: ["Python", "Bash", "Ngspice", "Xschem"]
         },
         {
-          name: "Eagle Project",
+          name: "Zilch Game Engine",
+          timeframe: "Ongoing",
           description:
-            "Created an orienteering course for my Eagle Scout project, contributing to community development."
+            "Personal project evolving a dice game from C++ prototypes to a Java-based architecture that applies object-oriented patterns for extensibility.",
+          tech: ["Java", "C++", "Game Design"]
+        },
+        {
+          name: "Web Portfolio Management",
+          timeframe: "Ongoing",
+          description:
+            "Maintain personal and client-facing sites built with Vue and Vitesse, focusing on responsive UI design and performance.",
+          tech: ["Vue", "Vitesse", "TypeScript"]
         }
-      ]
-    }
+      ],
+      skills: {
+        programmingLanguages: [
+          "C",
+          "C++",
+          "Java",
+          "Python",
+          "TypeScript",
+          "HTML & CSS",
+          "JavaScript",
+          "SystemVerilog",
+          "VHDL",
+          "Swift",
+          "MATLAB",
+          "RISC-V Assembly"
+        ],
+        frameworksAndTools: [
+          "Vue",
+          "Vitesse",
+          "React",
+          "SwiftUI",
+          "NumPy",
+          "Pandas",
+          "Matplotlib"
+        ],
+        competencies: [
+          "Embedded systems design",
+          "Signal processing & data analysis",
+          "Radiation-effects simulation",
+          "Wireless & sensor integration",
+          "Technical instruction and mentorship"
+        ],
+        spokenLanguages: [
+          "English",
+          "Spanish (fluent)",
+          "Portuguese (conversational)"
+        ]
+      },
+      achievements: [
+        "Eagle Scout, Boy Scouts of America",
+        "Phi Eta Sigma Honor Society member"
+      ],
+      teaching: {
+        rate: 40,
+        summary:
+          "I work with kids and teens to build confidence in programming, STEM fundamentals, and conversational Spanish through personalized lessons.",
+        focusAreas: ["Programming", "STEM enrichment", "Spanish"],
+        link: "https://classes.jacobdanderson.net"
+      }
+    } as UserProfile
   }),
-  
-  // Define actions for fetching or mutating the state
-  actions: {
-    // Example: Fetch user profile data from an API
-    fetchUserProfile() {
-      // Implementation for fetching user profile data
-    }
-  },
-  
-  // Define getters to compute derived state or access specific parts of the state
+
+  actions: {},
+
   getters: {
-    // Example getter for getting all project names
-    projectNames: (state) =>
-      state.userProfile.projects.map((project) => project.name)
+    projectNames: (state) => state.userProfile.projects.map((project) => project.name)
   }
 });

--- a/front-end/src/styles/main.css
+++ b/front-end/src/styles/main.css
@@ -2,86 +2,92 @@
 @import "./tailwind.css";
 @import "./markdown.css";
 
+:root {
+  --page-max-width: 1100px;
+  --page-horizontal-padding: clamp(1rem, 5vw, 2.5rem);
+  --brand-primary: #0f766e;
+  --brand-accent: #0d9488;
+  --neutral-900: #0f172a;
+  --neutral-700: #1f2937;
+  --neutral-500: #4b5563;
+  --surface: #ffffff;
+  --background-gradient: radial-gradient(circle at top, rgba(240, 253, 250, 0.95), #f1f5f9 65%);
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
 html,
 body,
 #app {
-	height: 100%;
-	margin: 0;
-	padding: 0;
+  min-height: 100%;
+  margin: 0;
+  padding: 0;
 }
 
 html.dark {
-	background: #121212;
-	color-scheme: dark;
+  background: #0f172a;
+  color-scheme: dark;
 }
-
-#nprogress {
-	pointer-events: none;
-}
-
-#nprogress .bar {
-	background: rgb(13, 148, 136);
-	opacity: 0.75;
-	position: fixed;
-	z-index: 1031;
-	top: 0;
-	left: 0;
-	width: 100%;
-	height: 2px;
-}
-
-/**************
-*   General   *
-**************/
 
 body {
-	background-color: #f5f5f5;
-	font-size: 110%;
-	margin: 0;
+  background: var(--background-gradient);
+  color: var(--neutral-700);
+  line-height: 1.6;
 }
 
-.content {
-	margin: 20px;
+main {
+  max-width: var(--page-max-width);
+  margin: 0 auto;
+  padding: 2.5rem var(--page-horizontal-padding) 4rem;
 }
 
-/******************
-*   Router View   *
-******************/
-
-h1, h2 {
-	font-weight: bold;
-	text-align: center;
-	padding-bottom: 5px;
-	margin: 0;
-	color: #2a6496;
+h1,
+h2,
+h3 {
+  font-weight: 700;
+  color: var(--neutral-900);
 }
 
 h1 {
-	font-size: 200%;
+  font-size: clamp(2.1rem, 3vw, 3rem);
+  margin: 0;
 }
 
 h2 {
-	font-size: 150%;
+  font-size: clamp(1.5rem, 2.2vw, 2.1rem);
+}
+
+h3 {
+  font-size: clamp(1.25rem, 2vw, 1.6rem);
 }
 
 .page {
-	background-color: #f5f5f5;
+  max-width: 100%;
 }
 
 .item {
-	margin-bottom: 20px;
-	padding: 20px;
-	background-color: #fff;
-	border: 1px solid #ccc;
-	border-radius: 5px;
-	box-shadow: 0 2px 2px rgba(0, 0, 0, 0.1);
-	
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: center;
+  margin-bottom: 1.5rem;
+  padding: 1.5rem;
+  background-color: var(--surface);
+  border-radius: 18px;
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.08);
 }
 
 .item p {
-	margin-top: 10px;
+  margin-top: 0.5rem;
+  color: var(--neutral-500);
+}
+
+a {
+  color: var(--brand-accent);
+}
+
+a:hover,
+a:focus {
+  color: var(--brand-primary);
+}
+
+@media (max-width: 768px) {
+  main {
+    padding: 2rem 1.25rem 3rem;
+  }
 }


### PR DESCRIPTION
## Summary
- refresh the data store with up-to-date education, experience, skills, and teaching details from the latest resume
- redesign the home, about, contact, experience, and projects pages with modern cards, hero, and highlight styling
- add a dedicated classes page and update the navigation and footer to promote tutoring offerings

## Testing
- pnpm lint *(fails: missing dependency `@eslint/js` in the existing configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e702947884832ba0cb3d8e9d9e70cb